### PR TITLE
🐛 #4 - Removed brew install git and fixed brew install name for github client

### DIFF
--- a/src/os/installs/macos/git.sh
+++ b/src/os/installs/macos/git.sh
@@ -6,7 +6,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")" \
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-print_in_purple "\n   Git\n\n"
+print_in_purple "\n   Git Tools\n\n"
 
-brew_install "Git" "git"
-brew_install "GitHub CLI" "github/gh/gh"
+brew_install "GitHub CLI" "gh"


### PR DESCRIPTION
Fixes bug #4 with GH download and removes brew install git﻿
